### PR TITLE
Typo in fix?

### DIFF
--- a/nokhwa-bindings-windows/src/lib.rs
+++ b/nokhwa-bindings-windows/src/lib.rs
@@ -276,7 +276,7 @@ pub mod wmf {
         let mut device_list = vec![];
 
         // return early if we have no devices connected
-        if count >= 0 {
+        if count == 0 {
             return Ok(device_list)
         }
 


### PR DESCRIPTION
It seems like something happened that caused the check to enter early return both when cameras were found _and_ when none were found